### PR TITLE
Qeynos - Fix invalid string.format parameter list

### DIFF
--- a/qeynos/Guard_Jerith.lua
+++ b/qeynos/Guard_Jerith.lua
@@ -1,6 +1,6 @@
 function event_say(e)
   if(e.message:findi("hail")) then
-    e.self:QuestSay(e.other,string.format("Um, sorry, " .. e.other:GetName() .. ". I don't wish to be rude, but I must not be distracted while I am at my post. Commander Bayle trusted me with this watch and I will not let him down.",e.other:GetName()));
+    e.self:QuestSay(e.other,"Um, sorry, " .. e.other:GetName() .. ". I don't wish to be rude, but I must not be distracted while I am at my post. Commander Bayle trusted me with this watch and I will not let him down.");
   end
 end
 

--- a/qeynos/Guard_Wenbie.lua
+++ b/qeynos/Guard_Wenbie.lua
@@ -6,7 +6,7 @@ end
 
 function event_say(e)
 	if(e.message:findi("hail")) then
-		e.self:Say(string.format("Hello, " .. e.other:GetName() .. ". What brings you to Qeynos? Must be the mighty fine muffins over at [Voleen's Bakery]. I just love those muffins!",e.other:GetName()));
+		e.self:Say("Hello, " .. e.other:GetName() .. ". What brings you to Qeynos? Must be the mighty fine muffins over at [Voleen's Bakery]. I just love those muffins!");
 	elseif(e.message:findi("voleen's bakery")) then
 		e.self:Say("Oh, it will be easier for us both if I just show you where it is. Follow me. But be quick about it, because I have to get back to my patrol.");
 	end


### PR DESCRIPTION
string.format was called but text did not contain %s it was superfluous hence why i removed it