### PR TITLE
Quest Fixes and New Quests

### DIFF
--- a/airplane/Dirkog_Steelhand.lua
+++ b/airplane/Dirkog_Steelhand.lua
@@ -23,7 +23,7 @@ end
 function event_trade(e)
 	local item_lib = require("items");
 	
-	if(item_lib.check_turn_in(e.self, e.trade, {platinum == 500}, 0)) then
+	if(item_lib.check_turn_in(e.self, e.trade, {platinum = 500}, 0)) then
 		e.self:Say("Thank ye, laddie! He's awaitin' ya up top!");
 		eq.spawn2(71091,0,0,-586,767,176,64);
 		eq.depop();

--- a/butcher/Dapper_Blackhammer.lua
+++ b/butcher/Dapper_Blackhammer.lua
@@ -9,7 +9,7 @@ end
 
 function event_trade(e)
 	local item_lib = require("items");
-	if(item_lib.check_turn_in(e.self, e.trade, {item1 = 12880, item2 = 6552, platinum == 500})) then
+	if(item_lib.check_turn_in(e.self, e.trade, {item1 = 12880, item2 = 6552, platinum = 500})) then
 		e.self:Say("I thank ya for ya patronage. Here is what ya came here for. Now be careful who ya point this at. 'Tis quite sharp, " .. e.other:Race() .. ". Be off with ya now as I must get back ta workin here. Good day!");
 		e.other:SummonItem(6551);
 		e.other:AddEXP(25000);

--- a/northkarana/Capt_Linarius.lua
+++ b/northkarana/Capt_Linarius.lua
@@ -23,13 +23,14 @@ function event_trade(e)
 		e.self:Say("What a pity. Such a promising soldier. I thank you for ridding us of this corruption and offer you this as a reward. It is nothing more than junk which littered the roadways of the Plains of Karana. I hope you can find a use for it.");
 		e.other:SummonItem(eq.ChooseRandom(5369,9002)); -- Bunker Battle Blade , Round Shield
 		e.other:Ding();
+		-- confirmed live factions
 		e.other:Faction(135,10,0); -- Guards of Qeynos
-		e.other:Faction(9,10,0); -- Antonius Bayle
-		e.other:Faction(53,-10,0); -- Corrupt Qeynos Guards
-		e.other:Faction(33,-10,0); -- Circle Of Unseen Hands
-		e.other:Faction(217,10,0); -- Merchants of Qeynos 
+		e.other:Faction(9,1,0); -- Antonius Bayle
+		e.other:Faction(53,-1,0); -- Corrupt Qeynos Guards
+		e.other:Faction(33,-2,0); -- Circle Of Unseen Hands
+		e.other:Faction(217,1,0); -- Merchants of Qeynos 
 		e.other:AddEXP(2000);
-		e.other:GiveCash(19,0,8,0);
+		e.other:GiveCash(math.random(20),0,math.random(10),0);
 	elseif(item_lib.check_turn_in(e.self, e.trade, {item1 = 13304})) then -- Loyal Guards Bracelet (Guard Bracelet - 13304)
 		e.self:Say("You fool!!! You have slain a loyal defender of the guard!  Prepare to DIE!!!"); -- text made up
 		eq.attack(e.other:GetName());

--- a/overthere/Galdon_Vok_Nir.lua
+++ b/overthere/Galdon_Vok_Nir.lua
@@ -9,7 +9,7 @@ end
 function event_trade(e)
 	local item_lib = require("items");
 	--Turn in the 2 totems and the canopie of Di Nozok and 400 gold pieces
-	if(item_lib.check_turn_in(e.self, e.trade, {item1 = 12743, item2 = 12744, item3 = 12742, gold == 400})) then
+	if(item_lib.check_turn_in(e.self, e.trade, {item1 = 12743, item2 = 12744, item3 = 12742, gold = 400})) then
 		e.self:Say("A deal is a deal I suppose, many have attempt to do what I have asked, but fallen to the Overseer.");
 		e.other:QuestReward(e.self,0,0,0,0,12740); -- Give the player the Iksar Skull
 	end

--- a/overthere/Kurron_Ni.lua
+++ b/overthere/Kurron_Ni.lua
@@ -23,7 +23,7 @@ function event_trade(e)
 	local item_lib = require("items");
 	
 	if(e.other:GetClass() == 5 and e.other:HasItem(14383) == false) then
-		if(item_lib.check_turn_in(e.self, e.trade, {item1 = 3141, item2 = 3145, item3 = 3140, platinum == 900})) then --Platinum x 900, Darkforge Breastplate, Darkforge Greaves, Darkforge Helm
+		if(item_lib.check_turn_in(e.self, e.trade, {item1 = 3141, item2 = 3145, item3 = 3140, platinum = 900})) then --Platinum x 900, Darkforge Breastplate, Darkforge Greaves, Darkforge Helm
 			e.self:Say("Well done, " .. e.other:GetName() .. ", I honestly didn't expect to see you again. Yes, yes, this is perfect! My mission is nearly complete!");
 			e.other:Faction(342,3);
 			eq.unique_spawn(93006,0,0,e.self:GetX(),e.self:GetY(),e.self:GetZ(),e.self:GetHeading());

--- a/paw/Brother_Hayle.lua
+++ b/paw/Brother_Hayle.lua
@@ -13,12 +13,13 @@ function event_trade(e)
 
 	if(item_lib.check_turn_in(e.self, e.trade, {item1 = 18927})) then -- Temple Summons
 		e.self:Say("I am needed!! What am I doing here? I must return to the Temple of Life to commune with the Prime Healer. Rodcet Nife will give me more strength to finish this job. Thank you, young one! Take this key as a reward. Turn it into Tyokan in the temple shop. Safe journey to you!");
-		e.other:Faction(257,5,0); 		-- Priest of Life
-		e.other:Faction(183,5,0); 		-- Knights of Thunder
-		e.other:Faction(135,5,0); 		-- Guards of Qeynos
+		-- confirmed live factions
+		e.other:Faction(257,20,0); 		-- Priest of Life
+		e.other:Faction(183,6,0); 		-- Knights of Thunder
+		e.other:Faction(135,10,0); 		-- Guards of Qeynos
 		e.other:Faction(21,-5,0); 		-- BloodSabers
-		e.other:Faction(9,5,0); 		-- Antonious Bayle
-		e.other:QuestReward(e.self,0,0,0,0,13306,200);
+		e.other:Faction(9,3,0); 		-- Antonious Bayle
+		e.other:QuestReward(e.self,0,0,0,0,13306,200); -- T.O.L. 2020
 	end
 	if(item_lib.check_turn_in(e.self, e.trade, {item1 = 18936})) then -- A Sealed Note
 		e.self:Say("Finally!! I see that Ariska has found a noble knight to retrieve Soulfire. Per Ariska's orders I am not to give Soulfire to you until you can show me [proof of nobility]. You must honor both the Temple of Life as well as the Hall of Truth and to a high degree. Only then shall you hold Soulfire.");

--- a/qcat/Nomaria_Doseniar.lua
+++ b/qcat/Nomaria_Doseniar.lua
@@ -3,8 +3,29 @@ function event_say(e)
 		e.self:Say("Welcome! It is good to see our disciples can still outsmart the guards of Qeynos and make it to the Shrine of Bertoxxulous. Our ranks are best filled with disciples such as yourself. We have need of you. Do you wish to serve the Lord of Disease or not?");
 	elseif(e.message:findi("serve the lord of disease")) then
 		e.self:Say("Aye! That is good. Of late, we have heard news of a message that will be sent to the Treefolk of the Jaggedpine. Antonius Bayle will send word to the Jaggedpine that certain requests will be met. We must intercept this message. That is all you need to know. Go and find Antonius Bayle's messenger, Gharin, He should have the message. Get it by any means necessary and return it to me. Go now!");
+	elseif(e.message:findi("or not")) then
+		e.self:Say("We are not in the business of providing safe haven for cowards. Begone, and may your courage be found amongst the dead!");	
 	end
 end
+
+function event_trade(e)
+	local item_lib =require("items");
+
+	if(item_lib.check_turn_in(e.self, e.trade, {item1 = 18807})) then -- Sealed Letter [Note To Jaggedpine - real]
+		e.self:Say("Good work, child of the plague. Now take this forged note to Te'Anara of the Jaggedpine Treefolk. Be sure to watch your back, now. The guards of Qeynos surely know who you are by now. They will not stop to ask questions.");
+		e.other:SummonItem(18806); -- Sealed Letter [Note To Jaggedpine - fake]
+		e.other:Ding();
+		-- confirmed live factions
+		e.other:Faction(21,50); -- Bloodsabers
+		e.other:Faction(135,-7); -- Guards of Qeynos
+		e.other:Faction(235,5); -- Opal Dark Briar
+		e.other:Faction(257,-12); -- Priest of Life
+		e.other:Faction(53,2); -- Corrupt Qeynos Guards
+		e.other:GiveCash(0,math.random(5),0,0);
+		e.other:AddEXP(100);
+	end
+	item_lib.return_items(e.self, e.other, e.trade)
+end	
 
 --END of FILE Zone:qcat  ID:45087 -- Nomaria_Doseniar
 -------------------------------------------------------------------------------------------------

--- a/qey2hh1/Brother_Estle.lua
+++ b/qey2hh1/Brother_Estle.lua
@@ -32,13 +32,14 @@ function event_trade(e)
 		e.self:Say("Thank you. Now I may cleanse the bodies of the new converts and help them enter into a new life. I also have this. It was given to me by a dying gnoll of all things. They belong to Brother Hayle. The gnoll's last words were 'Free him.' Make sure High Priestess Jahnda gets this. Be swift!");
 		e.other:SummonItem(13911);
 		e.other:Ding();
-		e.other:Faction(257,10,0);
-		e.other:Faction(183,10,0);
-		e.other:Faction(135,10,0);
-		e.other:Faction(21,-10,0);
-		e.other:Faction(9,10,0);
+		--confirmed live factions
+		e.other:Faction(257,15,0);
+		e.other:Faction(183,4,0);
+		e.other:Faction(135,7,0);
+		e.other:Faction(21,-3,0);
+		e.other:Faction(9,2,0);
 		e.other:AddEXP(500);
-		e.other:GiveCash(0,1,0,0);
+		e.other:GiveCash(math.random(10),math.random(10),0,0);
 	end
 	item_lib.return_items(e.self, e.other, e.trade)
 end

--- a/qey2hh1/Pyzjn.lua
+++ b/qey2hh1/Pyzjn.lua
@@ -1,0 +1,5 @@
+function event_say(e)
+	if(e.message:findi("hail")) then
+			e.self:Say("Hail, " .. e.other:GetName() .. ". Pyzjn is working for Master Varsoon. If Pyzjn do good work maybe Master Varsoon tell Master Bruax he is worthy. Pyzjn must go now. All glory to the Plaguebringe! May you die a painful, oozing death.");	
+	end
+end

--- a/qey2hh1/Pyzjn.lua
+++ b/qey2hh1/Pyzjn.lua
@@ -3,3 +3,9 @@ function event_say(e)
 			e.self:Say("Hail, " .. e.other:GetName() .. ". Pyzjn is working for Master Varsoon. If Pyzjn do good work maybe Master Varsoon tell Master Bruax he is worthy. Pyzjn must go now. All glory to the Plaguebringe! May you die a painful, oozing death.");	
 	end
 end
+
+function event_combat(e)
+  if(e.joined == true) then
+    e.self:Say("Hmm. You offend Pyzjin. Your death come soon. Hail, Bertoxxulous!");
+  end
+end

--- a/qey2hh1/Tovax_Vmar.lua
+++ b/qey2hh1/Tovax_Vmar.lua
@@ -1,0 +1,5 @@
+function event_say(e)
+	if(e.message:findi("hail")) then
+		e.self:Say("What? Who the heck are you and how do you know my name?! Never mind... Just leave me alone!");	
+	end
+end

--- a/qeynos/Behroe_Dlexon.lua
+++ b/qeynos/Behroe_Dlexon.lua
@@ -3,9 +3,13 @@ function event_say(e)
     e.self:QuestSay(e.other,string.format("Ah, greetings, %s!  How are you this evening?  Hopefully, you are faring much better than I..  I'm stuck on the night watch here, and never get to see my lovely [Aenia].  Ah..  she is so sweet..  I wrote her this beautiful [ballad], but I fear she may never hear it.",e.other:GetName()));
   elseif(e.message:findi("aenia")) then
     e.self:QuestSay(e.other,"Aenia lives in North Qeynos in a little blue house near the Temple of Life with her overprotective father.  Last time he caught me there, he nearly killed me!");
-  elseif(e.message:findi("ballad")) then
-    e.self:QuestSay(e.other,"I wrote this little song for my dearest Aenia, but I can't sing it to her because I'm stuck here on watch duty.  You have a nice voice, " .. e.other:GetName() .. ", maybe you could go and sing my song to her for me, huh?  Just make sure you don't sing to Aenia when her father's around, 'cause like I said, he's already tried to kill me for seeing her.");
-    e.other:SummonItem(18026);
+  elseif(e.message:findi("ballad")) then  	
+  	if(e.other:GetFaction(e.self) > 5) then -- must be at least indifferent
+  		e.self:Say("The League of Antonican Bards is very displeased with your recent actions. And I don't particularly care for you, or your stench, either!");
+  	else
+	    e.self:QuestSay(e.other,"I wrote this little song for my dearest Aenia, but I can't sing it to her because I'm stuck here on watch duty.  You have a nice voice, " .. e.other:GetName() .. ", maybe you could go and sing my song to her for me, huh?  Just make sure you don't sing to Aenia when her father's around, 'cause like I said, he's already tried to kill me for seeing her.");
+	    e.other:SummonItem(18026);
+	   end
   end
 end
 
@@ -14,15 +18,17 @@ function event_trade(e)
   if(item_lib.check_turn_in(e.self, e.trade, {item1 = 18027})) then
     e.self:Say(string.format("Ah, thank you, kind %s.  You've made two foolish lovebirds very happy.  Please, take this..  Though it is not much, it will help keep you warm on those chilly Karana nights.  It is very good to have a friend such as yourself, and I will one day repay you for your kindness and generosity.",e.other:GetName()));
     e.other:SendSound();
-    e.other:Faction(192,2,0);
-    e.other:Faction(184,2,0);
-    e.other:Faction(135,2,0);
-    e.other:Faction(273,-2,0);
-    e.other:Faction(207,-2,0);
+    -- confirmed live factions
+    e.other:Faction(192,8,0);
+    e.other:Faction(184,1,0);
+    e.other:Faction(135,1,0);
+    e.other:Faction(273,-1,0);
+    e.other:Faction(207,-1,0);
     e.other:AddEXP(250);
   elseif(item_lib.check_turn_in(e.self, e.trade, {item1 = 18021})) then
     e.self:Emote(string.format("yawns and says, 'Oh, report time already again?  Yeah, here ya go, %s.  Be careful around here at night, I've been seeing some rough looking characters lurking about.",e.other:GetName()));
     e.other:SendSound();
+     -- confirmed live factions
     e.other:SummonItem(18023);
     e.other:Faction(192,10,0);
     e.other:Faction(184,1,0);
@@ -32,4 +38,8 @@ function event_trade(e)
     e.other:AddEXP(250);
   end
   item_lib.return_items(e.self, e.other, e.trade, e.text)
+end
+
+function event_death_complete(e)
+	e.self:Say("Your actions will not go unnoticed! The League of Antonican Bards has many members all over this continent.");
 end

--- a/qeynos2/Aenia_Ghenson.lua
+++ b/qeynos2/Aenia_Ghenson.lua
@@ -4,7 +4,15 @@ function event_say(e)
 	elseif(e.message:findi("boyfriend")) then
 		e.self:Say("My boyfriend's name is Behroe Dlexon.  He is so dreamy..  <sigh>..  But, I haven't been able to see him lately.  He works nights down at the docks, and with my father here all day, we just can't seem to get together.  Oh, how I wish I could speak with him..");
 	elseif(e.message:findi("oh glistening crimson rose, you would be such a catch. oh beautiful thornless rose, your essence has no match")) then
-		e.self:Say("Oh..   My Behroe is so sweet.  Oh, how I long to see him.  Please, oh please, kind Kajigger, can you do me but one favor? Here, quickly, before my father returns.  Take this letter to my love, Behroe.  I have no money to offer you, but as you are a friend of his, so are you a friend of mine, and I will not forget your good deeds, Kajigger.  Thank you and be safe.");
-		e.other:SummonItem(18027);
+		if(e.other:GetFaction(e.self) > 5) then -- must be at least indifferent
+			e.self:Say("Heh.. With all you've done, I'm surprised you're still alive.");
+		else
+			e.self:Say("Oh..   My Behroe is so sweet.  Oh, how I long to see him.  Please, oh please, kind Kajigger, can you do me but one favor? Here, quickly, before my father returns.  Take this letter to my love, Behroe.  I have no money to offer you, but as you are a friend of his, so are you a friend of mine, and I will not forget your good deeds, Kajigger.  Thank you and be safe.");
+			e.other:SummonItem(18027);
+		end
 	end
+end
+
+function event_death_complete(e)
+	e.self:Say("You can't break the Circle.. kill one, and.. there will always be another to take his place.. and.. take revenge.");
 end

--- a/qeynos2/Camlend_Serbold.lua
+++ b/qeynos2/Camlend_Serbold.lua
@@ -34,11 +34,12 @@ function event_trade(e)
 			e.self:Say("We thank you for your service. With Lord Grimrot's evil soul trapped in this scythe, all but the truly evil shadowknights would be able to wield it. I would like to present you with this as a token of our appreciation. Your devotion to life is supreme. Go now, and serve life.");
 			e.other:SummonItem(12238); -- Aegis of Life ID: 12238
 			e.other:Ding();
-			e.other:Faction(257,30,0); -- Priest of Life
-			e.other:Faction(183,30,0); -- Knight of Thunder
-			e.other:Faction(135,30,0); -- Guards of Qeynos
-			e.other:Faction(21,-55,0); -- Bloodsabers
-			e.other:Faction(9,30,0); -- Antonius Bayle
+			-- confirmed live factions
+			e.other:Faction(257,1,0); -- Priest of Life
+			e.other:Faction(183,1,0); -- Knight of Thunder
+			e.other:Faction(135,2,0); -- Guards of Qeynos
+			e.other:Faction(21,-1,0); -- Bloodsabers
+			e.other:Faction(9,1,0); -- Antonius Bayle
 			e.other:AddEXP(1000);
 			e.other:GiveCash(0,0,0,9);
 		end

--- a/qeynos2/Guard_Weleth.lua
+++ b/qeynos2/Guard_Weleth.lua
@@ -1,13 +1,13 @@
 function event_say(e)
 	if(e.message:findi("hail")) then
 		e.self:Say(string.format("Hail, %s. My name is Weleth Nagoh. In addition to my patrol, I am in charge of keeping the guardhouse stocked with supplies. I must get back to my duties. Farewell.",e.other:GetName()));
-	elseif(e.message:findi("crate")) then
-		e.self:Say("Oh, we just received a shipment of arrows from [Nesiff] in South Qeynos. The arrows in this box are missing their fletchings and I can't leave my patrol to take them back.");
 	elseif(e.message:findi("nesiff")) then
 		e.self:Say("Nesiff Tallaherd owns the wooden weapons shop in Merchant's Square in South Qeynos.");
 	elseif(e.message:findi("arrows")) then
 		e.self:Say("Oh, thank you! Here is the crate. Make sure [Nesiff] sends me back a new invoice. [Lieutenant Dagarok] would have my head if he found out this happened again!");
 		e.other:SummonItem(13925); -- Crate of Defective Arrows
+	elseif(e.message:findi("crate")) then
+		e.self:Say("Oh, we just received a shipment of arrows from [Nesiff] in South Qeynos. The arrows in this box are missing their fletchings and I can't leave my patrol to take them back.");
 	elseif(e.message:findi("Lieutenant Dagarok")) then
 		e.self:Say("Lieutenant Dagarok is the officer in charge of all of North Qeynos.  He is difficult to get along with and I [do not trust him].");
 	elseif(e.message:findi("do not trust him")) then

--- a/qeynos2/Priestess_Jahnda.lua
+++ b/qeynos2/Priestess_Jahnda.lua
@@ -22,6 +22,10 @@ function event_trade(e)
 		e.other:Faction(21,-25,0); -- Bloodsabers
 		e.other:Faction(9,15,0); -- Antonius Bayle
 		e.other:AddEXP(100);
+	elseif(item_lib.check_turn_in(e.self, e.trade, {item1 = 13911})) then -- PrayerBeads
+		e.self:Say("Oh my word!! This is terrible news. This belongs to Hayle Mool. He has been captured by the Splitpaw Clan while in Karana. You must go to his aid. We cannot do so at this time. Here. Be sure to hand him this summons. I will need to speak with him.");
+		e.other:SummonItem(18927); -- Temple Summons
+		e.other:Ding();
 	end
 	item_lib.return_items(e.self, e.other, e.trade)
 end

--- a/qeynos2/Tyokan_Mekase.lua
+++ b/qeynos2/Tyokan_Mekase.lua
@@ -2,17 +2,23 @@ function event_say(e)
 	if(e.message:findi("hail")) then
 		e.self:Say("Please look around. We have many items exclusively for the members of the Temple of Life. We also have [scroll strongboxes]. If you are unsure of what an item is, feel free to ask me.");
 	elseif(e.message:findi("scroll strongbox")) then
-		e.self:Say("The scroll strongboxes are merely personal safes. Most of the members use them. I am afraid all are taken, but if you are here to remove a scroll, merely hand me your key and I shall get it for you. I handle all 20 numbered keys and [Whysia] handles all 30 and 40 numbered keys.");
+		if(e.other:GetFaction(e.self) > 5) then -- must be at least indifferent
+			e.self:Say("Your mere presence disgusts me. Please remove yourself from my sight. Until you change yourself and your ways, you are unwelcome in the Temple of Life.");
+		else
+			e.self:Say("The scroll strongboxes are merely personal safes. Most of the members use them. I am afraid all are taken, but if you are here to remove a scroll, merely hand me your key and I shall get it for you. I handle all 20 numbered keys and [Whysia] handles all 30 and 40 numbered keys.");
+		end			
 	end
 end
 
 function event_trade(e)
 	local item_lib = require("items");
 
-	if(item_lib.check_turn_in(e.self, e.trade, {item1 = 13306})) then
+	if(e.other:GetFaction(e.self) < 5 and item_lib.check_turn_in(e.self, e.trade, {item1 = 13306})) then -- must be amiable
 		e.self:Say("Oh, turning in your key, are you? Very well, defender of life. Here you are.");
 		e.other:SummonItem(eq.ChooseRandom(15126,15126,15248));
 		e.other:Ding();
+	elseif(e.other:GetFaction(e.self) < 5 and item_lib.check_turn_in(e.self, e.trade, {item1 = 13306})) then -- must be amiable
+	
 	end
 	item_lib.return_items(e.self, e.other, e.trade)
 end

--- a/qeynos2/Tyokan_Mekase.lua
+++ b/qeynos2/Tyokan_Mekase.lua
@@ -6,7 +6,11 @@ function event_say(e)
 			e.self:Say("Your mere presence disgusts me. Please remove yourself from my sight. Until you change yourself and your ways, you are unwelcome in the Temple of Life.");
 		else
 			e.self:Say("The scroll strongboxes are merely personal safes. Most of the members use them. I am afraid all are taken, but if you are here to remove a scroll, merely hand me your key and I shall get it for you. I handle all 20 numbered keys and [Whysia] handles all 30 and 40 numbered keys.");
-		end			
+		end		
+	elseif(e.message:findi("whysia")) then
+		e.self:Say("Whysia works the night shift here.  She is quite the night owl.");
+	elseif(e.message:findi("prayer beads")) then
+		e.self:Say("The prayer beads are the blessed necklaces of the Priests of Life.  The beads have a few charges of minor healing.  I recharge them for all members in  good standing.  All I need are the beads and a donation of 100 gold pieces.");
 	end
 end
 

--- a/qeynos2/Tyokan_Mekase.lua
+++ b/qeynos2/Tyokan_Mekase.lua
@@ -17,8 +17,12 @@ function event_trade(e)
 		e.self:Say("Oh, turning in your key, are you? Very well, defender of life. Here you are.");
 		e.other:SummonItem(eq.ChooseRandom(15126,15126,15248));
 		e.other:Ding();
-	elseif(e.other:GetFaction(e.self) < 5 and item_lib.check_turn_in(e.self, e.trade, {item1 = 13306})) then -- must be amiable
-	
+	elseif(e.other:GetFaction(e.self) < 5 and item_lib.check_turn_in(e.self, e.trade, {item1 = 13296, gold=100})) then -- must be amiable
+		e.self:Say("I see your beads need to be charged. Very well, here you are. Use them and good health to you!!!");
+		e.other:SummonItem(13296);
+--	elseif(e.other:GetFaction(e.self) < 5 and item_lib.check_turn_in(e.self, e.trade, {item1 = 13296})) then -- must be amiable
+--		e.self:Say("As instructed by High Priestess Jahnda I must ask for the beads and a donation of 100 gold coins.");
+--		e.other:SummonItem(13296); -- TODO how to return prayer beats exactly as given e.g. 0 charges ?
 	end
 	item_lib.return_items(e.self, e.other, e.trade)
 end

--- a/qeynos2/Whysia_Flock.lua
+++ b/qeynos2/Whysia_Flock.lua
@@ -2,7 +2,11 @@ function event_say(e)
 	if(e.message:findi("hail")) then
 		e.self:Say(string.format("Good evening, %s. Feel free to take your time browsing. The temple shop is open night and day for your convenience. Most clerics need access to their [scroll strongbox] at all times.",e.other:GetName()));
 	elseif(e.message:findi("scroll strongbox")) then
-		e.self:Say("The scroll strongboxes are kept here. They are used by the temple clerics to hold their valuable scrolls. I tend to the 30 and 40 numbered boxes and [Tyokan] deals with the 20s. Presently all are taken and the waiting list is quite long. If you are here to turn in your key, then please do so. I shall get your scroll for you.");
+		if(e.other:GetFaction(e.self) > 5) then -- must be at least indifferent
+			e.self:Say("Your mere presence disgusts me. Please remove yourself from my sight. Until you change yourself and your ways, you are unwelcome in the Temple of Life.");
+		else
+			e.self:Say("The scroll strongboxes are kept here. They are used by the temple clerics to hold their valuable scrolls. I tend to the 30 and 40 numbered boxes and [Tyokan] deals with the 20s. Presently all are taken and the waiting list is quite long. If you are here to turn in your key, then please do so. I shall get your scroll for you.");
+		end
 	elseif(e.message:findi("tyokan")) then
 		e.self:Say("Tyokan Mekase is the day merchant here at the temple shop. He usually arrives around eight in the morning or so.");	
 	end

--- a/qeytoqrg/Holly_Windstalker.lua
+++ b/qeytoqrg/Holly_Windstalker.lua
@@ -1,5 +1,7 @@
 function event_say(e)
 	if(e.message:findi("hail")) then
 		e.self:Say(string.format("Well met. %s.  I am Holly Windstalker. Protector of the Pine.  What brings you out to the Qeynos Hills?  Not hunting. I hope. These stains on my blade are all that is left of the last adventurer I caught harming my bear and wolf friends.",e.other:GetName()));
+	elseif(e.message:findi("Protector of the Pine") or e.message:findi("Jaggedpine Treefolk")) then
+		e.self:Say("The Protectors of the Pine are a group of rangers who, along with the [Jaggedpine Treefolk], protect the wild bears and wolves of Surefall Glade and its surroundings.");
 	end
 end

--- a/qrg/Te-Anara.lua
+++ b/qrg/Te-Anara.lua
@@ -45,8 +45,18 @@ function event_trade(e)
 		e.other:Faction(267, 4,0); --QRG Protected Animals
 		e.other:Faction(347, -7,0); --Unkempt Druids
 		e.other:Faction(135, 4,0);   --Guards of Qeynos
-		e.other:AddEXP(16000);
+		e.other:AddEXP(5000);
 		e.other:GiveCash(0,math.random(10),math.random(5),0);
+	elseif(item_lib.check_turn_in(e.self, e.trade, {item1 = 18806})) then -- Sealed Letter [Note To Jaggedpine - fake]
+		e.self:Say("This is dreadful news. We have been nothing but kind neighbors to Qeynos. Now Antonius Bayle wishes to abuse our friendship. This will not sit well with the others. Begone, messenger!");
+		e.other:Ding();
+		-- confirmed live factions		
+		e.other:Faction(159, -30,0); --Jaggedpine Treefolk
+		e.other:Faction(265, -7,0); --Protectors of Pine
+		e.other:Faction(267, -4,0); --QRG Protected Animals
+		e.other:Faction(347, 7,0); --Unkempt Druids
+		e.other:Faction(135, -4,0);   --Guards of Qeynos
+		e.other:AddEXP(5000);
 	end
 	item_lib.return_items(e.self, e.other, e.trade)
 end


### PR DESCRIPTION
New Quest Gharin's Note (evil)
Nomaria Doseniar - Add Turnin and Reward
Te'Anara - Add Turnin And Rewa

Pyzjin & Tovax Vmar
Added Missing Text Triggers

Quest: Corrupt Guards
Fixed Faction Reward

Quest: Aegis of Life
Fixed Faction Reward

Pyzjin
Added engage message

Holly Windstalker
Added missing dialog

Guard Weleth
Fix order of message trigger checks

Quest: Aenia and Behroe

Aenia Ghenson: Added faction checks and messages;Added death message;
Behroe Dlexon: Added faction checks and messages;Added death message;
Corrected Faction Reward

Quest: Blessed Oil
Quest can now be completed

Priestess Jahnda: Added quest turnin for PrayerBeads
Brother Estle: Fixed faction reward
Brother Hayle: Fixed faction reward
Tyokan Mekase: Added faction check for trigger phrase and quest turnin
Whysia Flock: Added faction check for trigger phrase

Added Quest Recharge Prayer Beads
Tyokan Mekase: Added missing dialog triggers and quest turn in

Various
Fixed a few turnin gold/plat comparison